### PR TITLE
Register block colors for tiles and fix lang issues

### DIFF
--- a/common/src/main/java/mtr/MTRClient.java
+++ b/common/src/main/java/mtr/MTRClient.java
@@ -157,6 +157,7 @@ public class MTRClient implements IPacket {
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_GRAVEL.get());
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_IRON_BLOCK.get());
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_METAL.get());
+			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_TILE.get());
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_PLANKS.get());
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_POLISHED_ANDESITE.get());
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_POLISHED_DIORITE.get());
@@ -190,6 +191,7 @@ public class MTRClient implements IPacket {
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_GRAVEL_SLAB.get());
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_IRON_BLOCK_SLAB.get());
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_METAL_SLAB.get());
+			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_TILE_SLAB.get());
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_PLANKS_SLAB.get());
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_POLISHED_ANDESITE_SLAB.get());
 			RegistryClient.registerBlockColors(Blocks.STATION_COLOR_POLISHED_DIORITE_SLAB.get());

--- a/common/src/main/resources/assets/mtr/lang/en_us.json
+++ b/common/src/main/resources/assets/mtr/lang/en_us.json
@@ -15,6 +15,8 @@
 	"block.minecraft.iron_block_slab": "Iron Block Slab",
 	"block.minecraft.metal": "Metal Block",
 	"block.minecraft.metal_slab": "Metal Slab",
+	"block.minecraft.tile": "Tessera Tile",
+	"block.minecraft.tile_slab": "Tessera Tile Slab",
 	"block.minecraft.planks": "Wooden Planks",
 	"block.minecraft.planks_slab": "Wooden Planks Slab",
 	"block.minecraft.purpur_block_slab": "Purpur Block Slab",


### PR DESCRIPTION
2 changes:
- Registered block colors in `MTRClient`
- Added lang for the new tiles